### PR TITLE
[Build] Add catch-all fallback for linux host architectures

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,6 +205,10 @@ case $host in
           AC_DEFINE([ARCH], [ARM], [Architecture.])
           AC_DEFINE([WSIZE], [64], [Size of word in this architecture.])
           ;;
+       *)
+          CPU_ARCH="none"
+          AC_DEFINE([WSIZE], [64], [Size of word in this architecture.])
+          ;;
      esac
      ;;
   *mingw*)


### PR DESCRIPTION
Needed to support builds on s390x, ppc64le, and risc64