### PR TITLE
[Trivial] Clean compiler warnings

### DIFF
--- a/src/hkdf.hpp
+++ b/src/hkdf.hpp
@@ -45,7 +45,6 @@ class HKDF256 {
 
     static void Expand(uint8_t* okm, size_t L, const uint8_t* prk, const uint8_t* info, const size_t infoLen) {
         assert(L <= 255 * HASH_LEN); // L <= 255 * HashLen
-        assert(infoLen >= 0);
         size_t N = (L + HASH_LEN - 1) / HASH_LEN; // Round up
         size_t bytesWritten = 0;
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -59,7 +59,7 @@ class Util {
     static std::string HexStr(const uint8_t* data, size_t len) {
         std::stringstream s;
         s << std::hex;
-        for (int i=0; i < len; ++i)
+        for (size_t i=0; i < len; ++i)
             s << std::setw(2) << std::setfill('0') << static_cast<int>(data[i]);
         return s.str();
     }
@@ -67,7 +67,7 @@ class Util {
     static std::string HexStr(const std::vector<uint8_t> &data) {
         std::stringstream s;
         s << std::hex;
-        for (int i=0; i < data.size(); ++i)
+        for (size_t i=0; i < data.size(); ++i)
             s << std::setw(2) << std::setfill('0') << static_cast<int>(data[i]);
         return s.str();
     }


### PR DESCRIPTION
Remove a couple warnings (asserting unsigned `size_t` >=0, and comparing signed/unsigned expressions).