### PR TITLE
[Test] Complete test for Aggregated Shamir's Secret Sharing Scheme and DKG protocol.

### DIFF
--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -40,7 +40,7 @@ PrivateKey PrivateKey::FromBytes(const Bytes& bytes, bool modOrder)
 }
 
 // Construct a private key from a bytearray.
-PrivateKey PrivateKey::FromByteVector(const std::vector<uint8_t> bytes, bool modOrder)
+PrivateKey PrivateKey::FromByteVector(const std::vector<uint8_t>& bytes, bool modOrder)
 {
     return PrivateKey::FromBytes(Bytes(bytes), modOrder);
 }

--- a/src/privatekey.hpp
+++ b/src/privatekey.hpp
@@ -37,7 +37,7 @@ class PrivateKey {
     static PrivateKey FromBytes(const Bytes& bytes, bool modOrder = false);
 
     // Construct a private key from a bytearray.
-    static PrivateKey FromByteVector(const std::vector<uint8_t> bytes, bool modOrder = false);
+    static PrivateKey FromByteVector(const std::vector<uint8_t>& bytes, bool modOrder = false);
 
     // Aggregate many private keys into one (sum of keys mod order)
     static PrivateKey Aggregate(std::vector<PrivateKey> const &privateKeys);

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1263,10 +1263,11 @@ TEST_CASE("Threshold Signatures") {
         PrivateKey sk;
         // Free coefficient of P(x)
         G1Element pk;
+        // Free coefficient of SIG(x)
+        G2Element sig;
         // Coefficients vectors
         std::vector<PrivateKey> sks;
         std::vector<G1Element> pks;
-        std::vector<G2Element> sigs;
         // Internal shares (contributions)
         std::map<RawData, PrivateKey> sksShares;
         std::map<RawData, G1Element> pksShares;
@@ -1375,34 +1376,19 @@ TEST_CASE("Threshold Signatures") {
         // Then verify that the recovered G2Element validates with the recovered G1Element (lagrange interpolation results for SIGa() and Pa() respectively)
 
         // Let's aggregate all the verification vectors to obtain Pa():
-        std::vector<G1Element> finalVerifVector;
-        for (auto& participant : participants) {
-            if (finalVerifVector.empty()) {
-                finalVerifVector = participant.pks;
-            } else {
-                // Aggregate the vectors
-                std::vector<G1Element> verifVectorInternal(finalVerifVector.size());
-                for (int i = 0; i < finalVerifVector.size(); i++) {
-                    auto& coefficient = finalVerifVector.at(i);
-                    auto& coefficient2 = participant.pks.at(i);
-                    verifVectorInternal[i] = coefficient + coefficient2;
-                }
-                finalVerifVector = verifVectorInternal;
+        std::vector<G1Element> finalVerifVector(participants[0].pks);
+        for (int j = 1; j < participants.size(); j++) {
+            for (int i = 0; i < finalVerifVector.size(); i++) {
+                finalVerifVector[i] += participants[j].pks.at(i);
             }
         }
 
         // Data to be signed.
         std::vector<uint8_t> msgHash = getRandomSeed();
         for (auto& participant : participants) {
-            // Load SIG() polynomial coefficients vector
-            for (int i = 0; i < m; i++) {
-                PrivateKey sk = participant.sks[i];
-                G1Element pk = participant.pks[i];
-                G2Element sig = bls::Threshold::Sign(sk, Bytes(msgHash));
-                participant.sigs.emplace_back(sig);
-                REQUIRE(bls::Threshold::Verify(pk, Bytes(msgHash), {sig}));
-            }
-
+            // Load SiG(0) value for each participant
+            participant.sig = bls::Threshold::Sign(participant.sk, Bytes(msgHash));
+            REQUIRE(bls::Threshold::Verify(participant.pk, Bytes(msgHash), {participant.sig}));
             // Craft the participant.skShare sig
             G2Element aggrSig = bls::Threshold::Sign(participant.skShare, Bytes(msgHash));
             // Send it to every other participant which will receive the
@@ -1415,18 +1401,11 @@ TEST_CASE("Threshold Signatures") {
             }
         }
 
-        // Let's aggregate all the SIGx() vectors to obtain SIGa():
-        std::vector<G2Element> finalSIGVector;
-        for (auto& participant : participants) {
-            if (finalSIGVector.empty()) {
-                finalSIGVector = participant.sigs;
-            } else {
-                std::vector<G2Element> sigsVectorInternal(finalSIGVector.size());
-                for (int i = 0; i < finalSIGVector.size(); i++) {
-                    sigsVectorInternal[i] = finalSIGVector.at(i) + participant.sigs.at(i);
-                }
-                finalSIGVector = sigsVectorInternal;
-            }
+        // Let's aggregate all the SIG(0) values to obtain SIGa(0)
+        // This will be checked for equality against the recovered threshold signature
+        G2Element finalSIG = participants[0].sig;
+        for (int j = 1; j < participants.size(); j++) {
+            finalSIG += participants[j].sig;
         }
 
         // Now that everyone has everyone's sigs, let's take a participant at random and remove some sigs, then try to recover and validate SIGa(0)
@@ -1450,8 +1429,10 @@ TEST_CASE("Threshold Signatures") {
                 aggrSigs.emplace_back(recvSigShare.second);
             }
 
+            REQUIRE(aggrSigs.size() == m);
+
             G2Element freeCoefficientSigs = bls::Threshold::SignatureRecover(aggrSigs, ids);
-            REQUIRE(freeCoefficientSigs == finalSIGVector[0]);
+            REQUIRE(freeCoefficientSigs == finalSIG);
             // This will validate against Pa(0)!
             G1Element freeCoefficientPks = finalVerifVector[0];
             REQUIRE(bls::Threshold::Verify(freeCoefficientPks, Bytes(msgHash), freeCoefficientSigs));
@@ -1477,6 +1458,12 @@ TEST_CASE("Threshold Signatures") {
             G2Element freeCoefficientSigs2 = bls::Threshold::SignatureRecover(aggrSigs, ids);
             REQUIRE(freeCoefficientSigs2.IsValid());
             REQUIRE(bls::Threshold::Verify(freeCoefficientPks, Bytes(msgHash), freeCoefficientSigs2));
+
+            // Now let's modify one sig share, aggregate again, and check that verification fails
+            aggrSigs[0] += G2Element::Generator();
+            G2Element freeCoefficientSigs3 = bls::Threshold::SignatureRecover(aggrSigs, ids);
+            REQUIRE(freeCoefficientSigs3.IsValid());
+            REQUIRE(!bls::Threshold::Verify(freeCoefficientPks, Bytes(msgHash), freeCoefficientSigs3));
         }
     }
 }

--- a/src/threshold.cpp
+++ b/src/threshold.cpp
@@ -277,8 +277,8 @@ namespace bls {
         return Poly::Evaluate(pks, id);
     }
 
-    G1Element Threshold::PublicKeyRecover(const std::vector<G1Element>& sks, const std::vector<Bytes>& ids) {
-        return Poly::LagrangeInterpolate(sks, ids);
+    G1Element Threshold::PublicKeyRecover(const std::vector<G1Element>& pks, const std::vector<Bytes>& ids) {
+        return Poly::LagrangeInterpolate(pks, ids);
     }
 
     G2Element Threshold::SignatureShare(const std::vector<G2Element>& sigs, const Bytes& id) {

--- a/src/threshold.hpp
+++ b/src/threshold.hpp
@@ -16,9 +16,9 @@ namespace bls {
         PrivateKey PrivateKeyRecover(const std::vector<PrivateKey>& sks, const std::vector<Bytes>& ids);
 
         G1Element PublicKeyShare(const std::vector<G1Element>& pks, const Bytes& id);
-        G1Element PublicKeyRecover(const std::vector<G1Element>& sks, const std::vector<Bytes>& ids);
+        G1Element PublicKeyRecover(const std::vector<G1Element>& pks, const std::vector<Bytes>& ids);
 
-        G2Element SignatureShare(const std::vector<G2Element>& sks, const Bytes& id);
+        G2Element SignatureShare(const std::vector<G2Element>& sigs, const Bytes& id);
         G2Element SignatureRecover(const std::vector<G2Element>& sigs, const std::vector<Bytes>& ids);
 
         G2Element Sign(const PrivateKey& privateKey, const Bytes& vecMessage);

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -53,7 +53,7 @@ class Util {
  public:
     static void Hash256(uint8_t* output, const uint8_t* message,
                         size_t messageLen) {
-        md_map_sh256(output, message, messageLen);
+        md_map_sh256(output, message, (int) messageLen);
     }
 
     static std::string HexStr(const uint8_t* data, size_t len) {
@@ -65,11 +65,7 @@ class Util {
     }
 
     static std::string HexStr(const std::vector<uint8_t> &data) {
-        std::stringstream s;
-        s << std::hex;
-        for (size_t i=0; i < data.size(); ++i)
-            s << std::setw(2) << std::setfill('0') << static_cast<int>(data[i]);
-        return s.str();
+        return HexStr(data.data(), data.size());
     }
 
     /*
@@ -104,7 +100,7 @@ class Util {
     /*
      * Converts a hex string into a vector of bytes.
      */
-    static std::vector<uint8_t> HexToBytes(const std::string hex) {
+    static std::vector<uint8_t> HexToBytes(const std::string& hex) {
         if (hex.size() % 2 != 0) {
             throw std::invalid_argument("Invalid input string, length must be multple of 2");
         }


### PR DESCRIPTION
Going one step further over the Threshold Signatures tests, validating that the correlation and aggregation BLS properties are working properly on top of the Shamir's Secret Sharing Scheme, verifying the DKG protocol and each participant share/sig validation step described in DIP6 [BLS M-of-N Threshold Scheme and Distributed Key Generation](https://github.com/dashpay/dips/blob/master/dip-0006/bls_m-of-n_threshold_scheme_and_dkg.md)

Plus corrected a duplicated `HexStr` function and few invalid function's args names.