### PR TITLE
Threshold:  don't copy the entire vector just to cache the initial size.

### DIFF
--- a/src/threshold.cpp
+++ b/src/threshold.cpp
@@ -162,8 +162,8 @@ namespace bls {
     BLSType Poly::Evaluate(const std::vector<BLSType>& vecIn, const Bytes& id) {
         typedef PolyOps<BLSType> Ops;
         Ops ops;
-        std::vector<BLSType> vec = vecIn;
-        if (vec.size() < 2) {
+        const int vecSize = vecIn.size();
+        if (vecSize < 2) {
             throw std::length_error("At least 2 coefficients required");
         }
 
@@ -172,9 +172,9 @@ namespace bls {
         bn_read_bin(x, id.begin(), Poly::nIdSize);
         ops.ModOrder(x);
 
-        BLSType y = vecIn[vec.size() - 1];
+        BLSType y = vecIn[vecSize - 1];
 
-        for (int i = (int) vec.size() - 2; i >= 0; i--) {
+        for (int i = (int) vecSize - 2; i >= 0; i--) {
             y = ops.Mul(y, x);
             y = ops.Add(y, vecIn[i]);
         }


### PR DESCRIPTION
auto-descriptive title. 
The vector is being copied to a temp variable for no reason.