### PR TITLE
Bug: invalid G1 and G2 cached in PrivateKey

### DIFF
--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -87,6 +87,7 @@ PrivateKey& PrivateKey::operator=(const PrivateKey& other)
 {
     CheckKeyData();
     other.CheckKeyData();
+    InvalidateCaches();
     bn_copy(keydata, other.keydata);
     return *this;
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -63,8 +63,12 @@ TEST_CASE("class PrivateKey") {
         REQUIRE(!pk3.IsZero());
         REQUIRE(pk1 != pk2);
         REQUIRE(pk3 == pk2);
+        REQUIRE(pk2.GetG1Element().IsValid()); // cache previous g1
+        REQUIRE(pk2.GetG2Element().IsValid()); // cache previous g2
         pk2 = pk1;
         REQUIRE(pk1 == pk2);
+        REQUIRE(pk1.GetG1Element() == pk2.GetG1Element());  // currently failing
+        REQUIRE(pk1.GetG2Element() == pk2.GetG2Element());
         REQUIRE(pk3 != pk2);
     }
     SECTION("Move {constructor|assignment operator}") {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -67,7 +67,7 @@ TEST_CASE("class PrivateKey") {
         REQUIRE(pk2.GetG2Element().IsValid()); // cache previous g2
         pk2 = pk1;
         REQUIRE(pk1 == pk2);
-        REQUIRE(pk1.GetG1Element() == pk2.GetG1Element());  // currently failing
+        REQUIRE(pk1.GetG1Element() == pk2.GetG1Element());
         REQUIRE(pk1.GetG2Element() == pk2.GetG2Element());
         REQUIRE(pk3 != pk2);
     }


### PR DESCRIPTION
Pretty serious bug in the copy-assignment operator, discovered after a long investigation with @furszy over an intermittent failure in a unit test for deterministic masternodes in Core.

For reference, pull request submitted upstream: https://github.com/Chia-Network/bls-signatures/pull/289