### PR TITLE
[GA][Build] Bump GA workers to non-deprecated versions

### DIFF
--- a/.github/workflows/build-autotools.yml
+++ b/.github/workflows/build-autotools.yml
@@ -14,28 +14,28 @@ jobs:
       matrix:
         config:
           - name: ARM 32-bit
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: arm-linux-gnueabihf
             arch: armhf
             apt_get: gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
             arch_packages: libgmp-dev:armhf libsodium-dev:armhf
 
           - name: ARM 64-bit
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: aarch64-linux-gnu
             arch: arm64
             apt_get: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
             arch_packages: libgmp-dev:arm64 libsodium-dev:arm64
 
           #- name: i686 Linux
-          #  os: ubuntu-18.04
+          #  os: ubuntu-20.04
           #  host: i686-pc-linux-gnu
           #  arch: armhf
           #  apt_get: gcc-multilib g++-multilib
           #  arch_packages: libgmp-dev:i386 libsodium-dev:i386
 
           - name: x86_64 Linux
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: x86_64-unknown-linux-gnu
             arch: armhf # dummy arch
             apt_get: gcc-multilib g++-multilib
@@ -43,8 +43,8 @@ jobs:
             unit_tests: true
 
           - name: x86_64 MacOS
-            os: macos-10.15
-            host: x86_64-apple-darwin19.6.0
+            os: macos-11
+            host: x86_64-apple-darwin20.6.0
             brew_install: autoconf automake libtool gmp libsodium
             cc: clang
             cxx: clang++

--- a/.github/workflows/build-autotools.yml
+++ b/.github/workflows/build-autotools.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Get Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Arches
         if: matrix.config.arch

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,14 +14,14 @@ jobs:
     steps:
     - name: Cancel previous runs on the same branch
       if: ${{ github.ref != 'refs/heads/main' }}
-      uses: styfle/cancel-workflow-action@0.7.0
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       name: Install Python
       with:
         python-version: '3.8'

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-11, ubuntu-20.04]
 
     steps:
     - name: Cancel previous runs on the same branch
@@ -71,10 +71,10 @@ jobs:
     - name: Test pure python implementation
       run: |
         python python-impl/impl-test.py
-        
+
     - name: Install emsdk
       uses: mymindstorm/setup-emsdk@v9
-      
+
     - name: Test javascript bindings
       run: |
         emcc -v

--- a/configure.ac
+++ b/configure.ac
@@ -419,6 +419,12 @@ AX_PTHREAD
 
 AC_SEARCH_LIBS([clock_gettime],[rt])
 
+case $host in
+  *mingw*)
+     AC_CHECK_LIB([ssp], [main], [], AC_MSG_ERROR([libssp missing]))
+  ;;
+esac
+
 AC_MSG_CHECKING([whether to build runtest])
 if test x$use_tests = xyes; then
   AC_MSG_RESULT([yes])


### PR DESCRIPTION
Ubuntu 18.04 workers are deprecated and will be fully unsupported in April 2023.
macOS 10.15 workers are deprecated and will be fully unsupported in December 2022.

Also fixes an issue with windows cross-compiling on Ubuntu 20.04