### PR TITLE
[Build] Add syslib memory include to threshold.cpp

### DIFF
--- a/src/threshold.cpp
+++ b/src/threshold.cpp
@@ -6,6 +6,8 @@
 
 #include "schemes.hpp"
 
+#include <memory>
+
 static std::unique_ptr<bls::CoreMPL> pThresholdScheme(new bls::BasicSchemeMPL);
 
 /**


### PR DESCRIPTION
Newer versions of GCC require this explicit include.