### PR TITLE
[GA] Bump action-apt to `master` version

### DIFF
--- a/.github/workflows/build-autotools.yml
+++ b/.github/workflows/build-autotools.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Setup Arches
         if: matrix.config.arch
-        uses: ryankurte/action-apt@v0.3.0
+        uses: ryankurte/action-apt@master
         with:
           arch: ${{ matrix.config.arch }}
           packages: ${{ matrix.config.arch_packages }}


### PR DESCRIPTION
use `master` for now to appease node 16 version requirement until the repo's maintainer tags a new version.