### PR TITLE
Update Relic git-tag

### DIFF
--- a/js-bindings/wrappers/BignumWrapper.cpp
+++ b/js-bindings/wrappers/BignumWrapper.cpp
@@ -17,7 +17,7 @@
 
 namespace js_wrappers {
 Bignum::Bignum() {
-    bn_init(&content, 1);
+    bn_make(&content, 1);
 }
 
 Bignum::~Bignum() {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 if (DEFINED ENV{RELIC_MAIN})
   set(RELIC_GIT_TAG "origin/main")
 else ()
-  set(RELIC_GIT_TAG "1885ae3b681c423c72b65ce1fe70910142cf941c")
+  set(RELIC_GIT_TAG "e6209fd80e07203b865983faee635fa1f85d6c9f")
 endif ()
 
 message(STATUS "Relic will be built from: ${RELIC_GIT_TAG}")


### PR DESCRIPTION
On GCC 11 there has been issues with the relic compiling using the wrong git tag to avoid the error
`typedef struct ALIGNME( 64 ) __blake2s_state wrong order in blake2.h`

https://github.com/Chia-Network/bls-signatures/pull/244 for reference