### PR TITLE
CMake: Squelch implicit conversion warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ ENDIF()
 
 project(BLS)
 
-set(BUILD_BLS_TESTS 1 CACHE INTEGER "")
-set(BUILD_BLS_BENCHMARKS 1 CACHE INTEGER "")
+set(BUILD_BLS_TESTS "1" CACHE STRING "")
+set(BUILD_BLS_BENCHMARKS "1" CACHE STRING "")
 
 message(STATUS "Build tests: ${BUILD_BLS_TESTS}")
 message(STATUS "Build benchmarks: ${BUILD_BLS_BENCHMARKS}")
@@ -41,9 +41,9 @@ if(EMSCRIPTEN)
   # emscripten needs arch set to be none since it can't compile assembly
   set(ARCH "" CACHE STRING "")
   # emscripten is a 32 bit compiler
-  set(WSIZE 32 CACHE INTEGER "")
+  set(WSIZE "32" CACHE STRING "Relic - Processor word size")
 else()
-  set(WSIZE 64 CACHE INTEGER "")
+  set(WSIZE "64" CACHE STRING "Relic - Processor word size")
 endif()
 
 set(TIMER "CYCLE" CACHE STRING "")
@@ -54,7 +54,7 @@ set(SHLIB "OFF" CACHE STRING "")
 set(MULTI "PTHREAD" CACHE STRING "")
 set(DOCUM "off" CACHE STRING "")
 
-set(FP_PRIME 381 CACHE INTEGER "")
+set(FP_PRIME "381" CACHE STRING "Relic - Prime modulus size")
 
 IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(SEED "UDEV" CACHE STRING "")
@@ -75,9 +75,9 @@ set(FPX_METHD "INTEG;INTEG;LAZYR" CACHE STRING "")
 set(EP_PLAIN "off" CACHE STRING "")
 set(EP_SUPER "off" CACHE STRING "")
 # Disable relic tests and benchmarks
-set(TESTS 0 CACHE INTEGER "")
-set(BENCH 0 CACHE INTEGER "")
-set(QUIET 1 CACHE INTEGER "")
+set(TESTS "0" CACHE STRING "Relic - Number of times each test is ran")
+set(BENCH "0" CACHE STRING "Relic - Number of times each benchmark is ran")
+set(QUIET "on" CACHE STRING "Relic - Build with printing disabled")
 
 set(PP_EXT "LAZYR" CACHE STRING "")
 set(PP_METHD "LAZYR;OATEP" CACHE STRING "")


### PR DESCRIPTION
A number of caches were being implicitly converted from `INTEGER` to `STRING`, which triggers a warning in CMake. Remedy the situation by explicitly storing those caches as `STRING` to begin with.

Ref: https://github.com/Chia-Network/bls-signatures/pull/263

Extracted from: #12